### PR TITLE
Clippy opt 1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,8 @@
-﻿################################################################################
-# This .gitignore file was automatically created by Microsoft(R) Visual Studio.
-################################################################################
-
-*.diagsession
+﻿target
+*.o
+*.pyc
+*.swp
+*.jar
+*.class
+*.lock
+**/benchmark

--- a/Rust/Cargo.lock
+++ b/Rust/Cargo.lock
@@ -1,0 +1,4 @@
+[[package]]
+name = "fftbenchmark"
+version = "0.1.0"
+

--- a/Rust/Cargo.toml
+++ b/Rust/Cargo.toml
@@ -4,3 +4,12 @@ version = "0.1.0"
 authors = ["Zsolt Krüpl <hg2ecz@ham.hu>"]
 
 [dependencies]
+
+[profile.release]
+opt-level = 3
+debug = false
+rpath = false
+lto = false
+debug-assertions = false
+codegen-units = 1
+panic = 'unwind'

--- a/Rust/src/fft.rs
+++ b/Rust/src/fft.rs
@@ -1,78 +1,78 @@
 use std;
 
 pub struct Fourier {
-	phase_vector: [[f64; 2]; 32]
+    phase_vector: [[f64; 2]; 32]
 }
 
 impl Fourier {
-	pub fn new() -> Fourier {
-		let mut result = Fourier { 
-			phase_vector: [[0.0; 2]; 32] 
-		};
+    pub fn new() -> Fourier {
+        let mut result = Fourier { 
+            phase_vector: [[0.0; 2]; 32] 
+        };
 
-		for (i, pv) in result.phase_vector.iter_mut().enumerate().take(32) {
-			let point = f64::from(2 << i);
-			pv[0] = (-2.0 * std::f64::consts::PI / (point as f64)).cos();
-			pv[1] = (-2.0 * std::f64::consts::PI / (point as f64)).sin();
-		}
+        for (i, pv) in result.phase_vector.iter_mut().enumerate().take(32) {
+            let point = f64::from(2 << i);
+            pv[0] = (-2.0 * std::f64::consts::PI / (point as f64)).cos();
+            pv[1] = (-2.0 * std::f64::consts::PI / (point as f64)).sin();
+        }
 
-		result
-	}
+        result
+    }
 
-	// Public function
-	pub fn fft(&self, log2point: u32, xy_out: &mut [[f64; 2]], xy_in: &[[f64; 2]]) {
-		for (i, &xyi) in xy_in.iter().enumerate().take(1<<log2point) {
-			let mut brev: usize = i;
+    // Public function
+    pub fn fft(&self, log2point: u32, xy_out: &mut [[f64; 2]], xy_in: &[[f64; 2]]) {
+        for (i, &xyi) in xy_in.iter().enumerate().take(1<<log2point) {
+            let mut brev: usize = i;
 
-			brev = ((brev & 0xaaaaaaaa) >> 1) | ((brev & 0x55555555) << 1);
-			brev = ((brev & 0xcccccccc) >> 2) | ((brev & 0x33333333) << 2);
-			brev = ((brev & 0xf0f0f0f0) >> 4) | ((brev & 0x0f0f0f0f) << 4);
-			brev = ((brev & 0xff00ff00) >> 8) | ((brev & 0x00ff00ff) << 8);
-			brev = (brev >> 16) | (brev << 16);
+            brev = ((brev & 0xaaaa_aaaa) >> 1) | ((brev & 0x5555_5555) << 1);
+            brev = ((brev & 0xcccc_cccc) >> 2) | ((brev & 0x3333_3333) << 2);
+            brev = ((brev & 0xf0f0_f0f0) >> 4) | ((brev & 0x0f0f_0f0f) << 4);
+            brev = ((brev & 0xff00_ff00) >> 8) | ((brev & 0x00ff_00ff) << 8);
+            brev = (brev >> 16) | (brev << 16);
 
-			brev >>= 32 - log2point;
-			xy_out[brev] = xyi;
-		}
+            brev >>= 32 - log2point;
+            xy_out[brev] = xyi;
+        }
 
-		// here begins the Danielson-Lanczos section;
-		let n: usize = 1 << log2point;
-		let mut l2pt: usize = 0;
-		let mut mmax: usize = 1;
+        // here begins the Danielson-Lanczos section;
+        let n: usize = 1 << log2point;
+        let mut l2pt: usize = 0;
+        let mut mmax: usize = 1;
 
-		while n > mmax {
-			let istep: usize = mmax << 1;
-			//    double theta = -2*M_PI/istep;
-			//    double complex wphase_xy = cos(theta) + sin(theta)*I;
-			let wphase_xy: [f64; 2];
-			wphase_xy = self.phase_vector[l2pt];
-			l2pt += 1;
-			let mut w_xy: [f64; 2] = [1.0, 0.0];
+        while n > mmax {
+            let istep: usize = mmax << 1;
+            //    double theta = -2*M_PI/istep;
+            //    double complex wphase_xy = cos(theta) + sin(theta)*I;
+            let wphase_xy: [f64; 2];
+            wphase_xy = self.phase_vector[l2pt];
+            l2pt += 1;
+            let mut w_xy: [f64; 2] = [1.0, 0.0];
 
-			for m in 0..mmax {
-				//        for i in (m .. n).step_by(istep) { -- now unstable
-				let mut i = m;
+            for m in 0 .. mmax {
+                //        for i in (m .. n).step_by(istep) { -- now unstable
+                let mut i = m;
 
-				while i < n {
-					//        let temp_xY: [f64; 2] = w_xy * xy_out[i+mmax]; -- missing complex arithmetic
-					//        xy_out[i+mmax]  = xy_out[i] - temp_xY;
-					//        xy_out[i     ] += temp_xY;
-					let temp_x: f64 = w_xy[0] * xy_out[i + mmax][0] - w_xy[1] * xy_out[i + mmax][1];
-					let temp_y: f64 = w_xy[0] * xy_out[i + mmax][1] + w_xy[1] * xy_out[i + mmax][0];
-					xy_out[i + mmax][0] = xy_out[i][0] - temp_x;
-					xy_out[i + mmax][1] = xy_out[i][1] - temp_y;
-					xy_out[i][0] += temp_x;
-					xy_out[i][1] += temp_y;
-					i += istep;
-				}
+                while i < n {
+                    //        let temp_xY: [f64; 2] = w_xy * xy_out[i+mmax]; -- missing complex arithmetic
+                    //        xy_out[i+mmax]  = xy_out[i] - temp_xY;
+                    //        xy_out[i     ] += temp_xY;
+                    let temp_x: f64 = w_xy[0] * xy_out[i + mmax][0] - w_xy[1] * xy_out[i + mmax][1];
+                    let temp_y: f64 = w_xy[0] * xy_out[i + mmax][1] + w_xy[1] * xy_out[i + mmax][0];
+                    xy_out[i + mmax][0] = xy_out[i][0] - temp_x;
+                    xy_out[i + mmax][1] = xy_out[i][1] - temp_y;
+                    xy_out[i][0] += temp_x;
+                    xy_out[i][1] += temp_y;
+                    i += istep;
+                }
 
-				//        w_xy *= wphase_xy; // rotate -- missing complex arithmetic
-				let w_tmp = w_xy[0] * wphase_xy[0] - w_xy[1] * wphase_xy[1];
-				w_xy[1] = w_xy[0] * wphase_xy[1] + w_xy[1] * wphase_xy[0];
-				w_xy[0] = w_tmp;
-			}
+                //        w_xy *= wphase_xy; // rotate -- missing complex arithmetic
+                let w_tmp = w_xy[0] * wphase_xy[0] - w_xy[1] * wphase_xy[1];
+                w_xy[1] = w_xy[0] * wphase_xy[1] + w_xy[1] * wphase_xy[0];
+                w_xy[0] = w_tmp;
+            }
 
-			mmax = istep;
-		}
-	}
+            mmax = istep;
+        }
+    }
 }
 

--- a/Rust/src/fft.rs
+++ b/Rust/src/fft.rs
@@ -1,68 +1,78 @@
 use std;
 
-// Internal variables
-static mut PHASEVEC_EXIST: bool = false;
-static mut PHASEVEC: [[f64; 2]; 32] = [[0.0; 2]; 32];
-
-// Public function
-pub fn fft(log2point: u32, xy_out: &mut [[f64; 2]], xy_in: &[[f64; 2]]) {
-    unsafe {
-        if !PHASEVEC_EXIST {
-            for (i, pv) in PHASEVEC.iter_mut().enumerate().take(32) {
-                let point = f64::from(2 << i);
-                pv[0] = (-2.0 * std::f64::consts::PI / (point as f64)).cos();
-                pv[1] = (-2.0 * std::f64::consts::PI / (point as f64)).sin();
-            }
-            PHASEVEC_EXIST = true;
-        };
-    }
-    for (i, &xyi) in xy_in.iter().enumerate().take(1<<log2point) {
-        let mut brev: usize = i;
-        brev = ((brev & 0xaaaaaaaa) >> 1) | ((brev & 0x55555555) << 1);
-        brev = ((brev & 0xcccccccc) >> 2) | ((brev & 0x33333333) << 2);
-        brev = ((brev & 0xf0f0f0f0) >> 4) | ((brev & 0x0f0f0f0f) << 4);
-        brev = ((brev & 0xff00ff00) >> 8) | ((brev & 0x00ff00ff) << 8);
-        brev = (brev >> 16) | (brev << 16);
-
-        brev >>= 32 - log2point;
-        xy_out[brev] = xyi;
-    }
-
-    // here begins the Danielson-Lanczos section;
-    let n: usize = 1 << log2point;
-    let mut l2pt: usize = 0;
-    let mut mmax: usize = 1;
-
-    while n > mmax {
-        let istep: usize = mmax << 1;
-        //    double theta = -2*M_PI/istep;
-        //    double complex wphase_xy = cos(theta) + sin(theta)*I;
-        let wphase_xy: [f64; 2];
-        unsafe {
-            wphase_xy = PHASEVEC[l2pt];
-        }
-        l2pt += 1;
-        let mut w_xy: [f64; 2] = [1.0, 0.0];
-        for m in 0..mmax {
-            //        for i in (m .. n).step_by(istep) { -- now unstable
-            let mut i = m;
-            while i < n {
-                //        let temp_xY: [f64; 2] = w_xy * xy_out[i+mmax]; -- missing complex arithmetic
-                //        xy_out[i+mmax]  = xy_out[i] - temp_xY;
-                //        xy_out[i     ] += temp_xY;
-                let temp_x: f64 = w_xy[0] * xy_out[i + mmax][0] - w_xy[1] * xy_out[i + mmax][1];
-                let temp_y: f64 = w_xy[0] * xy_out[i + mmax][1] + w_xy[1] * xy_out[i + mmax][0];
-                xy_out[i + mmax][0] = xy_out[i][0] - temp_x;
-                xy_out[i + mmax][1] = xy_out[i][1] - temp_y;
-                xy_out[i][0] += temp_x;
-                xy_out[i][1] += temp_y;
-                i += istep;
-            }
-            //        w_xy *= wphase_xy; // rotate -- missing complex arithmetic
-            let w_tmp = w_xy[0] * wphase_xy[0] - w_xy[1] * wphase_xy[1];
-            w_xy[1] = w_xy[0] * wphase_xy[1] + w_xy[1] * wphase_xy[0];
-            w_xy[0] = w_tmp;
-        }
-        mmax = istep;
-    }
+pub struct Fourier {
+	phase_vector: [[f64; 2]; 32]
 }
+
+impl Fourier {
+	pub fn new() -> Fourier {
+		let mut result = Fourier { 
+			phase_vector: [[0.0; 2]; 32] 
+		};
+
+		for (i, pv) in result.phase_vector.iter_mut().enumerate().take(32) {
+			let point = f64::from(2 << i);
+			pv[0] = (-2.0 * std::f64::consts::PI / (point as f64)).cos();
+			pv[1] = (-2.0 * std::f64::consts::PI / (point as f64)).sin();
+		}
+
+		result
+	}
+
+	// Public function
+	pub fn fft(&self, log2point: u32, xy_out: &mut [[f64; 2]], xy_in: &[[f64; 2]]) {
+		for (i, &xyi) in xy_in.iter().enumerate().take(1<<log2point) {
+			let mut brev: usize = i;
+
+			brev = ((brev & 0xaaaaaaaa) >> 1) | ((brev & 0x55555555) << 1);
+			brev = ((brev & 0xcccccccc) >> 2) | ((brev & 0x33333333) << 2);
+			brev = ((brev & 0xf0f0f0f0) >> 4) | ((brev & 0x0f0f0f0f) << 4);
+			brev = ((brev & 0xff00ff00) >> 8) | ((brev & 0x00ff00ff) << 8);
+			brev = (brev >> 16) | (brev << 16);
+
+			brev >>= 32 - log2point;
+			xy_out[brev] = xyi;
+		}
+
+		// here begins the Danielson-Lanczos section;
+		let n: usize = 1 << log2point;
+		let mut l2pt: usize = 0;
+		let mut mmax: usize = 1;
+
+		while n > mmax {
+			let istep: usize = mmax << 1;
+			//    double theta = -2*M_PI/istep;
+			//    double complex wphase_xy = cos(theta) + sin(theta)*I;
+			let wphase_xy: [f64; 2];
+			wphase_xy = self.phase_vector[l2pt];
+			l2pt += 1;
+			let mut w_xy: [f64; 2] = [1.0, 0.0];
+
+			for m in 0..mmax {
+				//        for i in (m .. n).step_by(istep) { -- now unstable
+				let mut i = m;
+
+				while i < n {
+					//        let temp_xY: [f64; 2] = w_xy * xy_out[i+mmax]; -- missing complex arithmetic
+					//        xy_out[i+mmax]  = xy_out[i] - temp_xY;
+					//        xy_out[i     ] += temp_xY;
+					let temp_x: f64 = w_xy[0] * xy_out[i + mmax][0] - w_xy[1] * xy_out[i + mmax][1];
+					let temp_y: f64 = w_xy[0] * xy_out[i + mmax][1] + w_xy[1] * xy_out[i + mmax][0];
+					xy_out[i + mmax][0] = xy_out[i][0] - temp_x;
+					xy_out[i + mmax][1] = xy_out[i][1] - temp_y;
+					xy_out[i][0] += temp_x;
+					xy_out[i][1] += temp_y;
+					i += istep;
+				}
+
+				//        w_xy *= wphase_xy; // rotate -- missing complex arithmetic
+				let w_tmp = w_xy[0] * wphase_xy[0] - w_xy[1] * wphase_xy[1];
+				w_xy[1] = w_xy[0] * wphase_xy[1] + w_xy[1] * wphase_xy[0];
+				w_xy[0] = w_tmp;
+			}
+
+			mmax = istep;
+		}
+	}
+}
+

--- a/Rust/src/fft.rs
+++ b/Rust/src/fft.rs
@@ -1,66 +1,68 @@
 use std;
 
 // Internal variables
-static mut PHASEVEC_EXIST : bool = false;
+static mut PHASEVEC_EXIST: bool = false;
 static mut PHASEVEC: [[f64; 2]; 32] = [[0.0; 2]; 32];
 
 // Public function
-pub fn fft(log2point: u32, xy_out: &mut [[f64; 2] ], xy_in: &[[f64; 2] ]) {
+pub fn fft(log2point: u32, xy_out: &mut [[f64; 2]], xy_in: &[[f64; 2]]) {
     unsafe {
-      if !PHASEVEC_EXIST {;
-	for i in 0..32 {
-	    let point: i32 = 2<<i;
-	    PHASEVEC[i][0] = (-2.0*std::f64::consts::PI/(point as f64)).cos();
-	    PHASEVEC[i][1] = (-2.0*std::f64::consts::PI/(point as f64)).sin();
-	}
-	PHASEVEC_EXIST = true;
-      };
+        if !PHASEVEC_EXIST {
+            for (i, pv) in PHASEVEC.iter_mut().enumerate().take(32) {
+                let point = f64::from(2 << i);
+                pv[0] = (-2.0 * std::f64::consts::PI / (point as f64)).cos();
+                pv[1] = (-2.0 * std::f64::consts::PI / (point as f64)).sin();
+            }
+            PHASEVEC_EXIST = true;
+        };
     }
-    for i in 0 .. 1<<log2point {
-	let mut brev: usize = i;
-	brev = ((brev & 0xaaaaaaaa) >> 1) | ((brev & 0x55555555) << 1);
-	brev = ((brev & 0xcccccccc) >> 2) | ((brev & 0x33333333) << 2);
-	brev = ((brev & 0xf0f0f0f0) >> 4) | ((brev & 0x0f0f0f0f) << 4);
-	brev = ((brev & 0xff00ff00) >> 8) | ((brev & 0x00ff00ff) << 8);
-	brev = (brev >> 16) | (brev << 16);
+    for (i, &xyi) in xy_in.iter().enumerate().take(1<<log2point) {
+        let mut brev: usize = i;
+        brev = ((brev & 0xaaaaaaaa) >> 1) | ((brev & 0x55555555) << 1);
+        brev = ((brev & 0xcccccccc) >> 2) | ((brev & 0x33333333) << 2);
+        brev = ((brev & 0xf0f0f0f0) >> 4) | ((brev & 0x0f0f0f0f) << 4);
+        brev = ((brev & 0xff00ff00) >> 8) | ((brev & 0x00ff00ff) << 8);
+        brev = (brev >> 16) | (brev << 16);
 
-	brev >>= 32-log2point;
-	xy_out[brev] = xy_in[i];
+        brev >>= 32 - log2point;
+        xy_out[brev] = xyi;
     }
 
     // here begins the Danielson-Lanczos section;
-    let n: usize = 1<<log2point;
+    let n: usize = 1 << log2point;
     let mut l2pt: usize = 0;
     let mut mmax: usize = 1;
 
-    while n > mmax {;
-	let istep: usize = mmax<<1;
-//	double theta = -2*M_PI/istep;
-//	double complex wphase_xy = cos(theta) + sin(theta)*I;
-	let wphase_xy: [f64; 2];
-	unsafe { wphase_xy = PHASEVEC[l2pt]; }
-	l2pt+=1;
-	let mut w_xy: [f64; 2] = [1.0, 0.0];
-	for m in 0..mmax {;
-//	    for i in (m .. n).step_by(istep) { -- now unstable
-	    let mut i = m;
-	    while i < n {
-//		let temp_xY: [f64; 2] = w_xy * xy_out[i+mmax]; -- missing complex arithmetic
-//		xy_out[i+mmax]  = xy_out[i] - temp_xY;
-//		xy_out[i     ] += temp_xY;
-		let temp_x: f64 = w_xy[0] * xy_out[i+mmax][0] - w_xy[1] * xy_out[i+mmax][1];
-		let temp_y: f64 = w_xy[0] * xy_out[i+mmax][1] + w_xy[1] * xy_out[i+mmax][0];
-		xy_out[i+mmax][0]  = xy_out[i][0] - temp_x;
-		xy_out[i+mmax][1]  = xy_out[i][1] - temp_y;
-		xy_out[i     ][0] += temp_x;
-		xy_out[i     ][1] += temp_y;
-	        i += istep;
-	    }
-//	    w_xy *= wphase_xy; // rotate -- missing complex arithmetic
-	    let w_tmp = w_xy[0] * wphase_xy[0] - w_xy[1] * wphase_xy[1];
-	    w_xy[1] = w_xy[0] * wphase_xy[1] + w_xy[1] * wphase_xy[0];
-	    w_xy[0] = w_tmp;
-	}
-	mmax=istep;
+    while n > mmax {
+        let istep: usize = mmax << 1;
+        //    double theta = -2*M_PI/istep;
+        //    double complex wphase_xy = cos(theta) + sin(theta)*I;
+        let wphase_xy: [f64; 2];
+        unsafe {
+            wphase_xy = PHASEVEC[l2pt];
+        }
+        l2pt += 1;
+        let mut w_xy: [f64; 2] = [1.0, 0.0];
+        for m in 0..mmax {
+            //        for i in (m .. n).step_by(istep) { -- now unstable
+            let mut i = m;
+            while i < n {
+                //        let temp_xY: [f64; 2] = w_xy * xy_out[i+mmax]; -- missing complex arithmetic
+                //        xy_out[i+mmax]  = xy_out[i] - temp_xY;
+                //        xy_out[i     ] += temp_xY;
+                let temp_x: f64 = w_xy[0] * xy_out[i + mmax][0] - w_xy[1] * xy_out[i + mmax][1];
+                let temp_y: f64 = w_xy[0] * xy_out[i + mmax][1] + w_xy[1] * xy_out[i + mmax][0];
+                xy_out[i + mmax][0] = xy_out[i][0] - temp_x;
+                xy_out[i + mmax][1] = xy_out[i][1] - temp_y;
+                xy_out[i][0] += temp_x;
+                xy_out[i][1] += temp_y;
+                i += istep;
+            }
+            //        w_xy *= wphase_xy; // rotate -- missing complex arithmetic
+            let w_tmp = w_xy[0] * wphase_xy[0] - w_xy[1] * wphase_xy[1];
+            w_xy[1] = w_xy[0] * wphase_xy[1] + w_xy[1] * wphase_xy[0];
+            w_xy[0] = w_tmp;
+        }
+        mmax = istep;
     }
 }

--- a/Rust/src/main.rs
+++ b/Rust/src/main.rs
@@ -6,26 +6,29 @@ const LOG2FFTSIZE: u32 = 12;
 const FFT_REPEAT: u32 = 1000;
 
 const SIZE: usize = (1<<LOG2FFTSIZE);
-static mut XY         : [[f64; 2]; SIZE] = [[0.0; 2]; SIZE];
-static mut XY_OUT_FFT : [[f64; 2]; SIZE] = [[0.0; 2]; SIZE];
 
 fn main() {
+    let mut xy         : [[f64; 2]; SIZE] = [[0.0; 2]; SIZE];
+    let mut xy_out_fft : [[f64; 2]; SIZE] = [[0.0; 2]; SIZE];
 
-    unsafe {
-      for i in 0..SIZE/2    { XY[i] = [ 1.0, 0.0]; }
-      for i in SIZE/2..SIZE { XY[i] = [-1.0, 0.0]; }
-    }
+    for i in 0..SIZE/2    { xy[i] = [ 1.0, 0.0]; }
+    for i in SIZE/2..SIZE { xy[i] = [-1.0, 0.0]; }
 
 // FFT
     let start_time = Instant::now();
-    for _i in 0..FFT_REPEAT { unsafe {  fft::fft(LOG2FFTSIZE, &mut XY_OUT_FFT, &XY) } }
+
+    let fourier = fft::Fourier::new();
+    for _i in 0..FFT_REPEAT { 
+        fourier.fft(LOG2FFTSIZE, &mut xy_out_fft, &xy)
+    }
+    
     let elapsed_time = start_time.elapsed();
     let milliseconds = (elapsed_time.as_secs() as f64 * 1000.0) +
-		       (elapsed_time.subsec_nanos() as f64 / 1_000_000.0);
+                       (elapsed_time.subsec_nanos() as f64 / 1_000_000.0);
 
     println!("{} piece(s) of {} pt FFT;    {} ms/piece\n\n", FFT_REPEAT, SIZE, milliseconds/FFT_REPEAT as f64);
 
     for i in 0..6 {
-	unsafe { println!("{}  {} {}", i, XY_OUT_FFT[i][0], XY_OUT_FFT[i][1]) }
+        println!("{}\t({}; {})", i, xy_out_fft[i][0], xy_out_fft[i][1]);
     }
 }

--- a/Rust/src/main.rs
+++ b/Rust/src/main.rs
@@ -11,24 +11,29 @@ fn main() {
     let mut xy         : [[f64; 2]; SIZE] = [[0.0; 2]; SIZE];
     let mut xy_out_fft : [[f64; 2]; SIZE] = [[0.0; 2]; SIZE];
 
-    for i in 0..SIZE/2    { xy[i] = [ 1.0, 0.0]; }
-    for i in SIZE/2..SIZE { xy[i] = [-1.0, 0.0]; }
+    for item in xy.iter_mut().take(SIZE/2) { 
+        *item = [ 1.0, 0.0];
+    }
+    
+    for item in xy.iter_mut().take(SIZE).skip(SIZE/2) {
+        *item = [-1.0, 0.0]; 
+    }
 
-// FFT
+    // FFT
     let start_time = Instant::now();
 
     let fourier = fft::Fourier::new();
-    for _i in 0..FFT_REPEAT { 
+    for _i in 0 .. FFT_REPEAT { 
         fourier.fft(LOG2FFTSIZE, &mut xy_out_fft, &xy)
     }
     
     let elapsed_time = start_time.elapsed();
     let milliseconds = (elapsed_time.as_secs() as f64 * 1000.0) +
-                       (elapsed_time.subsec_nanos() as f64 / 1_000_000.0);
+                       (f64::from(elapsed_time.subsec_nanos()) / 1_000_000.0);
 
-    println!("{} piece(s) of {} pt FFT;    {} ms/piece\n\n", FFT_REPEAT, SIZE, milliseconds/FFT_REPEAT as f64);
+    println!("{} piece(s) of {} pt FFT;    {} ms/piece\n", FFT_REPEAT, SIZE, milliseconds/f64::from(FFT_REPEAT));
 
-    for i in 0..6 {
-        println!("{}\t({}; {})", i, xy_out_fft[i][0], xy_out_fft[i][1]);
+    for (i, item) in xy_out_fft.iter().enumerate().take(6) {
+        println!("{}\t({}; {})", i, item[0], item[1]);
     }
 }


### PR DESCRIPTION
* no more static variables --> local variables, phase vector and input-output array are together in the stack [**Speed improvement: 10% on my laptop, no change on Raspberry Pi 3**]
* no more unsafe
* some build-time fine-tuning
* no more clippy warnings

**Consequently, Rust is 6-9% slower on my laptop than the corresponding C code (fast-double)**

```
fuszenecker@linux:~/ProgrammingLanguageBenchmark-FFT_4096/Rust$ ../C-fast_double/benchmark 

  1000 piece(s) of 4096 pt FFT;    0.25681 ms/piece
  0      0.000000000      0.000000000      0.000000000
  1      2.000000000  -2607.594076291   2607.594843281
  2      0.000000000      0.000000000      0.000000000
  3      2.000000000   -869.196661891    869.198962863
  4      0.000000000      0.000000000      0.000000000
  5      2.000000000   -521.516360886    521.520195843
fuszenecker@linux:~/ProgrammingLanguageBenchmark-FFT_4096/Rust$ cargo run --release
    Finished release [optimized] target(s) in 0.0 secs
     Running `target/release/fftbenchmark`
1000 piece(s) of 4096 pt FFT;    0.274923025 ms/piece


0	(0; 0)
1	(2.0000000000001164; -2607.594076290663)
2	(0; 0)
3	(2.0000000000002705; -869.1966618912088)
4	(0; 0)
5	(1.999999999999989; -521.5163608863695)
```